### PR TITLE
add <algorithm> includes

### DIFF
--- a/Core/HdPackBuilder.cpp
+++ b/Core/HdPackBuilder.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "stdafx.h"
 #include "HdPackBuilder.h"
 

--- a/Core/HdPackLoader.cpp
+++ b/Core/HdPackLoader.cpp
@@ -1,4 +1,5 @@
 #include "stdafx.h"
+#include <algorithm>
 #include <unordered_map>
 #include "../Utilities/FolderUtilities.h"
 #include "../Utilities/StringUtilities.h"


### PR DESCRIPTION
Mesen, especially HdPackLoader.cpp and HdPackBuilder.cpp, doesn't compile without those includes.

```
../HdPackLoader.cpp:97:7: error: no member named 'transform' in namespace 'std'
        std::transform(tokens[1].begin(), tokens[1].end(), tokens[1].begin(), ::toupper);
        ~~~~~^
mkdir -p Core/obj.x86 && cd Core/obj.x86 && clang++ -fPIC -Wall --std=c++14 -O3 -m32 -Wno-parentheses -Wno-switch -c  ../stdafx.cpp
1 error generated.
```

```
../HdPackBuilder.cpp:268:10: error: no member named 'sort' in namespace 'std'
                                std::sort(tiles.begin(), tiles.end(), [=](std::pair<uint32_t, HdPackTileInfo...
                                ~~~~~^
../HdPackBuilder.cpp:370:10: error: no member named 'sort' in namespace 'std'
                                std::sort(tiles.begin(), tiles.end(), [=](std::pair<uint32_t, HdPackTileInfo...
                                ~~~~~^
2 errors generated.
```

Also, thanks so much for this project. This is the only nes emulator with Linux support that also has a debugger :)