### PR TITLE
Buildfix

### DIFF
--- a/Core/EmulationSettings.h
+++ b/Core/EmulationSettings.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include "stdafx.h"
 #include "MessageManager.h"
 #include "GameClient.h"


### PR DESCRIPTION
fix compile issue 'error: no matching  function for call std::find'
```

In file included from ../VideoDecoder.cpp:3:
In file included from ../VideoDecoder.h:8:
../EmulationSettings.h:392:8: error: no matching function for call to 'find'
                                if(std::find(otherKeys.begin(), otherKeys.end(), myKeys[i]) == otherKeys.end()) {
                                   ^~~~~~~~~
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/7.2.0/../../../../include/c++/7.2.0/bits/streambuf_iterator.h:369:5: note: candidate template ignored: could not match 'istreambuf_iterator' against '__normal_iterator'
    find(istreambuf_iterator<_CharT> __first,
    ^
1 error generated.

```