### PR TITLE
libretro: add missing helper items, fixes detection of Win10 SDK

### DIFF
--- a/Libretro/Makefile
+++ b/Libretro/Makefile
@@ -1,6 +1,13 @@
 STATIC_LINKING := 0
 AR             := ar
 
+SPACE :=
+SPACE := $(SPACE) $(SPACE)
+BACKSLASH :=
+BACKSLASH := \$(BACKSLASH)
+filter_out1 = $(filter-out $(firstword $1),$1)
+filter_out2 = $(call filter_out1,$(call filter_out1,$1))
+
 ifeq ($(platform),)
 platform = unix
 ifeq ($(shell uname -a),)


### PR DESCRIPTION
This is needed in order to get the buildbot working.