### PR TITLE
Libretro: Ignore libretro build files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ build/
 *.log
 *.scc
 
+# Libretro build files
+*.o
+
 # Visual C++ cache files
 ipch/
 *.aps
@@ -134,7 +137,6 @@ UpgradeLog*.htm
 # SQL Server files
 App_Data/*.mdf
 App_Data/*.ldf
-
 
 #LightSwitch generated files
 GeneratedArtifacts/

--- a/Libretro/.gitignore
+++ b/Libretro/.gitignore
@@ -1,0 +1,5 @@
+*.a
+*.so
+*.dylib
+*.bc
+*.dll


### PR DESCRIPTION
Ignores the build files from the libretro makefile so that they aren't accidentally committed.