### PR TITLE
MMC3_182: Correct switch fallthrough in WriteRegister()

### DIFF
--- a/Core/MMC3_182.h
+++ b/Core/MMC3_182.h
@@ -32,8 +32,8 @@ protected:
 				MMC3::WriteRegister(0xC000, value); 
 				MMC3::WriteRegister(0xC001, value);
 				break;
-			case 0xE000: MMC3::WriteRegister(0xE000, value);
-			case 0xE001: MMC3::WriteRegister(0xE001, value);
+			case 0xE000: MMC3::WriteRegister(0xE000, value); break;
+			case 0xE001: MMC3::WriteRegister(0xE001, value); break;
 		}
 	}
 };


### PR DESCRIPTION
A write to E000 would disable interrupts, fallthrough, and enable them again.