### PR TITLE
libretro: split retro_audio_sample_batch

### DIFF
--- a/Libretro/LibretroSoundManager.h
+++ b/Libretro/LibretroSoundManager.h
@@ -27,7 +27,15 @@ public:
 	virtual void PlayBuffer(int16_t *soundBuffer, uint32_t sampleCount, uint32_t sampleRate, bool isStereo) override
 	{
 		if(!_skipMode && _sendAudioBuffer) {
-			_sendAudioBuffer(soundBuffer, sampleCount);
+			uint32_t ptr = 0;
+			while(sampleCount)
+			{
+				uint32_t count = sampleCount > 1024 ? 1024 : sampleCount;
+				_sendAudioBuffer(soundBuffer + ptr, count);
+
+				ptr += count * (isStereo + 1);
+				sampleCount -= count;
+			}
 		}
 	}
 


### PR DESCRIPTION
frontend distorts audio beyond 1024 transfers (96000+ rates)