### PR TITLE
Debugger: Lua - Add new getLabelAddress() function

### DIFF
--- a/Core/LuaApi.cpp
+++ b/Core/LuaApi.cpp
@@ -21,6 +21,7 @@
 #include "KeyManager.h"
 #include "MemoryAccessCounter.h"
 #include "RomData.h"
+#include "LabelManager.h"
 
 #define lua_pushintvalue(name, value) lua_pushliteral(lua, #name); lua_pushinteger(lua, (int)value); lua_settable(lua, -3);
 #define lua_pushdoublevalue(name, value) lua_pushliteral(lua, #name); lua_pushnumber(lua, (double)value); lua_settable(lua, -3);
@@ -106,6 +107,7 @@ int LuaApi::GetLibrary(lua_State *lua)
 		{ "getScriptDataFolder", LuaApi::GetScriptDataFolder },
 		{ "getRomInfo", LuaApi::GetRomInfo },
 		{ "getLogWindowLog", LuaApi::GetLogWindowLog },
+		{ "getLabelAddress", LuaApi::GetLabelAddress },
 		{ NULL,NULL }
 	};
 
@@ -174,6 +176,22 @@ int LuaApi::GetLibrary(lua_State *lua)
 	lua_settable(lua, -3);
 
 	return 1;
+}
+
+int LuaApi::GetLabelAddress(lua_State *lua)
+{
+	LuaCallHelper l(lua);
+	l.ForceParamCount(1);
+	string label = l.ReadString();
+	checkminparams();
+	errorCond(label.length() == 0, "label cannot be empty");
+
+	std::shared_ptr<LabelManager> lblMan = _debugger->GetLabelManager();
+	int32_t value = lblMan->GetLabelRelativeAddress(label);
+	errorCond(value < 0, "label not found");
+
+	l.Return(value);
+	return l.ReturnCount();
 }
 
 int LuaApi::ReadMemory(lua_State *lua)

--- a/Core/LuaApi.h
+++ b/Core/LuaApi.h
@@ -16,6 +16,8 @@ public:
 	static void SetContext(ScriptingContext *context);
 	static int GetLibrary(lua_State *lua);
 
+	static int GetLabelAddress(lua_State *lua);
+
 	static int ReadMemory(lua_State *lua);
 	static int WriteMemory(lua_State *lua);
 	static int ReadMemoryWord(lua_State *lua);

--- a/Docs/content/apireference/MemoryAccess.md
+++ b/Docs/content/apireference/MemoryAccess.md
@@ -97,3 +97,18 @@ address - *Integer* A PPU address (Valid range: $0000-$3FFF)
 **Description**  
 Returns an integer representing the byte offset of the specified PPU address in CHR ROM based on the mapper's current configuration. Returns -1 when the specified address is not mapped to CHR ROM.
 
+## getLabelAddress ##
+
+**Syntax**  
+
+    emu.getLabelAddress(label)
+
+**Parameters**  
+label - *String* A label to look up.
+
+**Return value**  
+*Integer* The corresponding integer address.
+
+**Description**  
+Returns an integer representing the address of the specified label. The return value can be passed directly to `read()` and `readWord()`.
+

--- a/GUI.NET/Debugger/frmScript.cs
+++ b/GUI.NET/Debugger/frmScript.cs
@@ -515,6 +515,7 @@ namespace Mesen.GUI.Debugger
 			new List<string> {"func","emu.reset","emu.reset()","","","Resets the current game."},
 			new List<string> {"func","emu.resume","emu.resume()","","","Resumes execution after breaking."},
 			new List<string> {"func","emu.rewind","emu.rewind(seconds)","seconds - *Integer* The number of seconds to rewind","","Instantly rewinds the emulation by the number of seconds specified.\n Note: this can only be called from within a 'StartFrame' event callback."},
+			new List<string> {"func","emu.getLabelAddress","emu.getLabelAddress(label)","label - *String* The label to look up.","","Returns the integer address of the given label."},
 
 			new List<string> {"func","emu.getScreenBuffer","emu.getScreenBuffer()","", "*Array* 32-bit integers in ARGB format", "Returns an array of ARGB values for the entire screen (256px by 240px) - can be used with emu.setScreenBuffer() to alter the frame."},
 			new List<string> {"func","emu.setScreenBuffer","emu.setScreenBuffer(screenBuffer)", "screenBuffer - *Array* An array of 32-bit integers in ARGB format", "","Replaces the current frame with the contents of the specified array."},


### PR DESCRIPTION
This adds a new function `GetLabelAddress()` to the Lua API.  It takes a single string parameter of a label to lookup and returns its integer address.  The return value can be passed directly to read() and readWord().

The documentation has also been updated to reflect the changes.

I got tired of manually changing addresses in some of my debugging Lua scripts, so I added this function to get the addresses for me.