### PR TITLE
Add better support for mapper 198

### DIFF
--- a/Core/MMC3_198.h
+++ b/Core/MMC3_198.h
@@ -4,7 +4,10 @@
 #include "MMC3.h"
 
 //Most likely incorrect/incomplete, but works (with minor glitches) with the 2 games marked as mapper 198 that I am aware of.
-//Game 1: 吞食天地2  (CHR RAM, but uses chr banking?, has save ram at 6000-7FFF?)
+//Game 1: 吞食天地2  (CHR RAM, but uses chr banking?, has save ram at 6000-7FFF)
+//        吞食天地2  (English name is doae2) doae2 uses ram 5000-7FFF (Add Chinese character process program in 5000-5FFF)
+//        This rom has two version. One's size is 640KB(The version published by unknown in Hongkang)
+//        Another rom size is 1024KB(The version published by WaiXingKeji(Chinese named 外星科技) in China Mainland)
 //Game 2: Cheng Ji Si Han (ES-1110) (Ch)  (CHR RAM, work ram mirrored from 5000-7FFF?, doesn't use chr banking)
 //These games may actually use different mappers.
 class MMC3_198 : public MMC3
@@ -44,7 +47,7 @@ protected:
 	void WriteRegister(uint16_t addr, uint8_t value) override
 	{
 		if(addr == 0x8001 && (GetState().Reg8000 & 0x07) >= 6) {
-			_exRegs[(GetState().Reg8000 & 0x07) - 6] = value & (value >= 0x40 ? 0x4F : 0x3F);
+			_exRegs[(GetState().Reg8000 & 0x07) - 6] = value & 0x7F;
 		}
 		MMC3::WriteRegister(addr, value);
 	}


### PR DESCRIPTION


吞食天地2  (English name is doae2) doae2 uses ram 5000-7FFF (Add Chinese character process program in 5000-5FFF)

This rom has two version. One's size is 640KB(The version published by unknown in Hongkang)

Another rom size is 1024KB(The version published by WaiXingKeji(Chinese named 外星科技) in China Mainland)