### PR TITLE
Clean up Lua examples

### DIFF
--- a/GUI.NET/Dependencies/LuaScripts/DmcCapture.lua
+++ b/GUI.NET/Dependencies/LuaScripts/DmcCapture.lua
@@ -27,11 +27,11 @@ function Main()
       sample.addr[nbSample] = dmc.sampleAddr
       sample.length[nbSample] = dmc.sampleLength
       sample.period[nbSample] = dmc.period
-      emu.log(nbSample.." >>  $"..string.format("%X  ", dmc.sampleAddr)..string.format("%4d bytes  ",dmc.sampleLength)..string.format("%5d hertz ",freq)..stringR)  
+      emu.log(nbSample.." >>  $"..string.format("%X  ", dmc.sampleAddr)..string.format("%4d bytes  ",dmc.sampleLength)..string.format("%5d hertz ",freq)..stringR)
       if record then
         SampleRecord(dmc.sampleAddr, dmc.sampleLength, freq)
       end
-    end  
+    end
     if dmc.sampleAddr ~= lastSampleAddr or dmc.sampleLength ~= lastSampleLength or dmc.period ~= lastSamplePeriod then
       lastSampleAddr = dmc.sampleAddr
       lastSampleLength = dmc.sampleLength
@@ -53,7 +53,7 @@ function SelectRecord()
       emu.log("______________________________________________________________________\n")
       if record then
         emu.log("File path = "..emu.getScriptDataFolder().."\\\n")
-      end  
+      end
     end
   else
     hold = false
@@ -61,11 +61,11 @@ function SelectRecord()
   if record then
     stringR = "  recorded"
     emu.drawRectangle(193, 5, 42, 11, 0x404040, true, 1)
-    emu.drawRectangle(192, 4, 44, 13, 0x808080, false, 1)    
-    emu.drawString(196, 7, "RECORD", 0xFF0000, 0xFF000000, 1)    
+    emu.drawRectangle(192, 4, 44, 13, 0x808080, false, 1)
+    emu.drawString(196, 7, "RECORD", 0xFF0000, 0xFF000000, 1)
   else
-    stringR = "" 
-  end  
+    stringR = ""
+  end
 end
 
 
@@ -76,7 +76,7 @@ function SampleRecord(addr, length, freq)
   header[25] = freq & 255
   header[26] = freq >> 8
   header[29] = header[25]
-  header[30] = header[26]  
+  header[30] = header[26]
   header[41] = dataLen & 255
   header[42] = dataLen >> 8
   header[45] = 0x80
@@ -94,14 +94,14 @@ function SampleRecord(addr, length, freq)
         newSample = lastSample + 4
         if newSample == 256 then
           newSample = 252
-        end  
+        end
       else
         newSample = lastSample - 4
         if newSample == -4 then
           newSample = 0
         end
       end
-      fileOutput:write(string.char(newSample))        
+      fileOutput:write(string.char(newSample))
       lastSample = newSample
       bitMask = bitMask << 1
     end
@@ -123,5 +123,5 @@ header = {0x52,0x49,0x46,0x46,0x00,0x00,0x00,0x00,
           0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
           0x01,0x00,0x08,0x00,0x64,0x61,0x74,0x61,
           0x00,0x00,0x00,0x00}
-emu.addEventCallback(Main, emu.eventType.endFrame);
+emu.addEventCallback(Main, emu.eventType.endFrame)
 emu.displayMessage("Script", "DMC Capture")

--- a/GUI.NET/Dependencies/LuaScripts/DrawMode.lua
+++ b/GUI.NET/Dependencies/LuaScripts/DrawMode.lua
@@ -12,13 +12,13 @@ function Main()
     if not hold then
       hold = true
     else
-      emu.drawLine( oldX, oldY, mouse.x, mouse.y, 0xFF0000, 10000000)
+      emu.drawLine(oldX, oldY, mouse.x, mouse.y, 0xFF0000, 10000000)
     end
     oldX = mouse.x
     oldY = mouse.y
   else
     hold = false
-  end  
+  end
   if mouse.right then
     emu.clearScreen()
   end
@@ -26,5 +26,5 @@ end
 
 
 hold = false
-emu.addEventCallback(Main, emu.eventType.endFrame);
+emu.addEventCallback(Main, emu.eventType.endFrame)
 emu.displayMessage("Script", "Draw Mode")

--- a/GUI.NET/Dependencies/LuaScripts/Example.lua
+++ b/GUI.NET/Dependencies/LuaScripts/Example.lua
@@ -7,10 +7,10 @@
 function printInfo()
   --Get the emulation state
   state = emu.getState()
-  
+
   --Get the mouse's state (x, y, left, right, middle)
-  mouseState = emu.getMouseState()  
-  
+  mouseState = emu.getMouseState()
+
   --Select colors based on whether the left button is held down
   if mouseState.left == true then
     for y = 0, 239 do
@@ -19,31 +19,31 @@ function printInfo()
         color = emu.getPixel(x, y)
         emu.drawPixel(x, y, color & 0xFFFF, 1)
       end
-    end    
+    end
     bgColor = 0x30FF6020
     fgColor = 0x304040FF
-  else 
+  else
     bgColor = 0x302060FF
     fgColor = 0x30FF4040
   end
-  
+
   --Draw some rectangles and print some text
   emu.drawRectangle(8, 8, 128, 24, bgColor, true, 1)
   emu.drawRectangle(8, 8, 128, 24, fgColor, false, 1)
   emu.drawString(12, 12, "Frame: " .. state.ppu.frameCount, 0xFFFFFF, 0xFF000000, 1)
   emu.drawString(12, 21, "CPU Cycle: " .. state.cpu.cycleCount, 0xFFFFFF, 0xFF000000, 1)
-  
+
   emu.drawRectangle(8, 218, 193, 11, bgColor, true, 1)
-  emu.drawRectangle(8, 218, 193, 11, fgColor, false, 1)  
+  emu.drawRectangle(8, 218, 193, 11, fgColor, false, 1)
   emu.drawString(11, 220, "Hold left mouse button to switch colors", 0xFFFFFF, 0xFF000000, 1)
-  
+
   --Draw a block behind the mouse cursor - leaves a trail when moving the mouse
   emu.drawRectangle(mouseState.x - 2, mouseState.y - 2, 5, 5, 0xAF00FF90, true, 20)
   emu.drawRectangle(mouseState.x - 2, mouseState.y - 2, 5, 5, 0xAF000000, false, 20)
 end
 
 --Register some code (printInfo function) that will be run at the end of each frame
-emu.addEventCallback(printInfo, emu.eventType.endFrame);
+emu.addEventCallback(printInfo, emu.eventType.endFrame)
 
 --Display a startup message
 emu.displayMessage("Script", "Example Lua script loaded.")

--- a/GUI.NET/Dependencies/LuaScripts/GameBoyMode.lua
+++ b/GUI.NET/Dependencies/LuaScripts/GameBoyMode.lua
@@ -23,39 +23,39 @@ function Main()
         holdLeft = true
         stencil = true
         window_X = mouse.x - 80
-        window_Y = mouse.y - 72 
-      end 
-    end 
+        window_Y = mouse.y - 72
+      end
+    end
   else
-    holdLeft = false     
+    holdLeft = false
   end
 
   if stencil then
-    if window_X > 0 then 
+    if window_X > 0 then
       emu.drawRectangle(0, window_Y, window_X, 144, 0x000000, true)
     end
-    if window_X < 96 then 
+    if window_X < 96 then
       emu.drawRectangle(window_X + 160, window_Y, 96 - window_X, 144, 0x000000, true)
     end
     if window_Y > 0 then
       emu.drawRectangle(0, 0, 256, window_Y, 0x000000, true)
     end
-    if window_Y < 96 then   
-    emu.drawRectangle(0, window_Y + 144, 256, 96 - window_Y, 0x000000, true) 
+    if window_Y < 96 then
+    emu.drawRectangle(0, window_Y + 144, 256, 96 - window_Y, 0x000000, true)
     end
   end
- 
+
   if mouse.right then
     if not holdRight then
       holdRight = true
       UI_X = mouse.x - selectX
       UI_Y = mouse.y - selectY
-    end 
-    emu.drawRectangle(UI_X+16, UI_Y, 128, 16, 0x808080, true) 
+    end
+    emu.drawRectangle(UI_X+16, UI_Y, 128, 16, 0x808080, true)
     emu.drawRectangle(UI_X, UI_Y+16, 16, 128, 0x808080, true)
     for x = UI_X+16, UI_X+128, 16 do
       emu.drawRectangle(x, UI_Y, 17, 17, 0x404040)
-    end 
+    end
     for y = UI_Y+16, UI_Y+128, 16 do
       emu.drawRectangle(UI_X, y, 17, 17, 0x404040)
     end
@@ -64,20 +64,20 @@ function Main()
       paletteSpr = (mouse.y - 1 - UI_Y) >> 4
       offsetX = (UI_X & 0x0f) + 1
       offsetY = (UI_Y & 0x0f) + 1
-      emu.drawRectangle(((mouse.x - offsetX) & 0xf0) + offsetX, UI_Y+1, 15, 15, 0xff0000, true) 
-      emu.drawRectangle( UI_X+1, ((mouse.y - offsetY) & 0xf0) + offsetY, 15, 15, 0xff0000, true)
+      emu.drawRectangle(((mouse.x - offsetX) & 0xf0) + offsetX, UI_Y+1, 15, 15, 0xff0000, true)
+      emu.drawRectangle(UI_X+1, ((mouse.y - offsetY) & 0xf0) + offsetY, 15, 15, 0xff0000, true)
       emu.drawLine(UI_X+17, mouse.y, mouse.x, mouse.y, 0xff0000)
       emu.drawLine(mouse.x, UI_Y+17, mouse.x, mouse.y, 0xff0000)
       selectX = mouse.x - UI_X
-      selectY = mouse.y - UI_Y 
-    end 
+      selectY = mouse.y - UI_Y
+    end
     for i = 1,#text,3 do
       emu.drawString(UI_X + text[i], UI_Y + text[i+1], text[i+2], 0xffffff, 0xff000000)
     end
   else
     holdRight = false
   end
- 
+
   for palAddr = 0,0x0f,4 do
     emu.write(palAddr, color[paletteBg][1], emu.memType.palette)
     emu.write(palAddr + 1, color[paletteBg][2], emu.memType.palette)
@@ -86,9 +86,9 @@ function Main()
     emu.write(palAddr + 16, color[paletteBg][1], emu.memType.palette)
     emu.write(palAddr + 17, color[paletteSpr][1], emu.memType.palette)
     emu.write(palAddr + 18, color[paletteSpr][2], emu.memType.palette)
-    emu.write(palAddr + 19, color[paletteSpr][3], emu.memType.palette)     
+    emu.write(palAddr + 19, color[paletteSpr][3], emu.memType.palette)
   end
-end 
+end
 
 stencil = false
 holdLeft = false

--- a/GUI.NET/Dependencies/LuaScripts/Grid.lua
+++ b/GUI.NET/Dependencies/LuaScripts/Grid.lua
@@ -10,7 +10,7 @@ function Main()
     if not hold then
       hold = true
       mode = (mode + 1) % 3
-      emu.drawRectangle( 95, 87, 67, 11, 0x808080, false, 50)
+      emu.drawRectangle(95, 87, 67, 11, 0x808080, false, 50)
       if mode == 0 then
         size = 8
         emu.drawString(96, 89, "  8x8 Grid  ", 0xFFFFFF, 0x404040, 50)
@@ -23,13 +23,13 @@ function Main()
       end
     end
   else
-    hold = false  
+    hold = false
   end
   for i = 0, 239, size do
-    emu.drawLine( 0, i, 255, i, color, 1)
+    emu.drawLine(0, i, 255, i, color, 1)
   end
   for i = 0, 255, size do
-    emu.drawLine( i, 0, i, 239, color, 1)
+    emu.drawLine(i, 0, i, 239, color, 1)
   end
 end
 
@@ -38,5 +38,5 @@ color = 0xC0FF0000
 hold = false
 mode = 0
 size = 8
-emu.addEventCallback(Main, emu.eventType.endFrame);
+emu.addEventCallback(Main, emu.eventType.endFrame)
 emu.displayMessage("Script", "Grid")

--- a/GUI.NET/Dependencies/LuaScripts/LogParallax.lua
+++ b/GUI.NET/Dependencies/LuaScripts/LogParallax.lua
@@ -5,15 +5,15 @@
 -- Draws a red line over each scanline that CPU writes to $2005 occurred
 -----------------------
 
-PPUSCROLL = 0x2005;
-colorCode = 0x4000FF00;
+PPUSCROLL = 0x2005
+colorCode = 0x4000FF00
 
 function onScroll(address, value)
-  local state = emu.getState();
-  emu.log("Scrolling change. Scanline: "..state.ppu.scanline.." Value:"..value);
-  local color = colorCode + state.ppu.scanline;
+  local state = emu.getState()
+  emu.log("Scrolling change. Scanline: "..state.ppu.scanline.." Value:"..value)
+  local color = colorCode + state.ppu.scanline
   emu.drawLine(0, state.ppu.scanline, 256, state.ppu.scanline, color, 1)
-end;
+end
 
-emu.addMemoryCallback(onScroll, emu.memCallbackType.cpuWrite, PPUSCROLL);
+emu.addMemoryCallback(onScroll, emu.memCallbackType.cpuWrite, PPUSCROLL)
 emu.displayMessage("Script", "Log Parallax")

--- a/GUI.NET/Dependencies/LuaScripts/ModifyScreen.lua
+++ b/GUI.NET/Dependencies/LuaScripts/ModifyScreen.lua
@@ -14,7 +14,7 @@ end
 
 function makeRed()
   local buffer = emu.getScreenBuffer()
-  for i, p in pairs(buffer) do 
+  for i, p in pairs(buffer) do
     buffer[i] = buffer[i] & 0xFFFF0000
   end
   emu.setScreenBuffer(buffer)
@@ -39,7 +39,7 @@ function blink()
    local blinkPeriod = 24*5
    local blinkTime = 10
    if frame % blinkPeriod < blinkTime then
-     for i, p in pairs(buffer) do 
+     for i, p in pairs(buffer) do
        buffer[i] = 0x0000FF00
      end
    end
@@ -101,11 +101,11 @@ function checkKeys()
   elseif emu.isKeyPressed("4") and shaderType ~= 4 then
     shaderType = 4
     emu.displayMessage("Info", "Shader Waves selected")
-  end 
+  end
 end
 
-emu.addEventCallback(endFrame, emu.eventType.endFrame);
-emu.addEventCallback(checkKeys, emu.eventType.inputPolled);
+emu.addEventCallback(endFrame, emu.eventType.endFrame)
+emu.addEventCallback(checkKeys, emu.eventType.inputPolled)
 
 local infoStr = "Press keys from 0 to 4 to change shaders"
 emu.displayMessage("Info", infoStr)

--- a/GUI.NET/Dependencies/LuaScripts/NtscSafeArea.lua
+++ b/GUI.NET/Dependencies/LuaScripts/NtscSafeArea.lua
@@ -8,22 +8,22 @@
 -- Red: "Danger Zone" (Top and bottom 8 pixels)
 --      Most TVs hide all of this.
 --
--- Gray: Outside the "Title Safe Area". 
+-- Gray: Outside the "Title Safe Area".
 --       Some TVs may hide portions of this.
 --       Text, etc. should not appear here.
 -----------------------
 
 function drawSafeArea()
-  local red = 0x40FF0000;
-  local gray = 0x60505050;
+  local red = 0x40FF0000
+  local gray = 0x60505050
 
   emu.drawRectangle(0, 0, 256, 8, red, true)
   emu.drawRectangle(0, 232, 256, 8, red, true)
-  
+
   emu.drawRectangle(0, 8, 16, 224, gray, true)
   emu.drawRectangle(240, 8, 16, 224, gray, true)
   emu.drawRectangle(16, 8, 224, 16, gray, true)
   emu.drawRectangle(16, 216, 224, 16, gray, true)
 end
 
-emu.addEventCallback(drawSafeArea, emu.eventType.endFrame);
+emu.addEventCallback(drawSafeArea, emu.eventType.endFrame)

--- a/GUI.NET/Dependencies/LuaScripts/ReverseMode.lua
+++ b/GUI.NET/Dependencies/LuaScripts/ReverseMode.lua
@@ -18,7 +18,7 @@ function Main()
     end
   end
   emu.setScreenBuffer(bufferO)
-end  
+end
 
 emu.addEventCallback(Main, emu.eventType.inputPolled)
 emu.displayMessage("Script", "Reverse Mode")

--- a/GUI.NET/Dependencies/LuaScripts/SpriteBox.lua
+++ b/GUI.NET/Dependencies/LuaScripts/SpriteBox.lua
@@ -7,7 +7,7 @@
 --
 -- Each scanline with overflow will be marked by a small red line on the left side of the screen.
 -- As the number of sprites over the limit increases, the line will progressively turn orange, yellow and then white.
--- 
+--
 -- Sprites with a red box as normal priority sprites, those in blue are background priority sprites.
 --
 -- 4 different display modes exist (change mode by right-clicking on the screen):
@@ -30,14 +30,14 @@ function Main()
     height = 16
   else
     height = 8
-  end  
+  end
 
   for oamAddr = 0, 252, 4 do
     spriteY = emu.read(oamAddr, emu.memType.oam) + 1
     if spriteY < 240 then
       spritesOnScreen = spritesOnScreen + 1
       for i = 0, (height - 1 ) do
-        spritesOnLine[spriteY + i] = spritesOnLine[spriteY + i] + 1 
+        spritesOnLine[spriteY + i] = spritesOnLine[spriteY + i] + 1
       end
     end
     spriteX = emu.read(oamAddr + 3, emu.memType.oam)
@@ -46,7 +46,7 @@ function Main()
     else
       color = 0x0000ff
     end
-    if mode == 2 then 
+    if mode == 2 then
       alpha = oamAddr / 4 * 0x03000000 + 0x20000000
     end
     emu.drawRectangle(spriteX, spriteY, 8, height, color + alpha, fill, 1)
@@ -60,8 +60,8 @@ function Main()
       elseif overflow > 8 then
         overflowColor = 0xFFFF00 + (((overflow - 1) & 7) << 5)
       else
-        overflowColor = 0xFF0000 + (((overflow - 1) & 7) << 13)  
-      end  
+        overflowColor = 0xFF0000 + (((overflow - 1) & 7) << 13)
+      end
       emu.drawLine(0, scanline, 7, scanline, overflowColor, 1)
       counterColor = 0xFF0000
     end
@@ -78,7 +78,7 @@ function SelectMode()
     if not holdButton then
       mode = (mode + 1) & 3
       emu.drawRectangle(94, 87, 68, 12, 0x404040, true, 50)
-      emu.drawRectangle(93, 86, 70, 14, 0x808080, false, 50)    
+      emu.drawRectangle(93, 86, 70, 14, 0x808080, false, 50)
       if mode == 0 then
         fill = false
         alpha = 0x40000000
@@ -96,11 +96,11 @@ function SelectMode()
       holdButton = true
     end
   else
-    holdButton = false  
-  end  
+    holdButton = false
+  end
 end
 
-  
+
 mode = 0
 alpha = 0x40000000
 holdButton = false


### PR DESCRIPTION
- Remove extraneous semi-colons
- Remove spaces after opening paren on functions
- Remove trailing spaces on lines
- Add newlines as last byte of file where applicable