### PR TITLE
Apply premultiply alpha to HD images and add alpha blending to custom background images

### DIFF
--- a/Core/HdNesPack.cpp
+++ b/Core/HdNesPack.cpp
@@ -21,11 +21,10 @@ HdNesPack::~HdNesPack()
 
 void HdNesPack::BlendColors(uint8_t output[4], uint8_t input[4])
 {
-	uint8_t alpha = input[3] + 1;
 	uint8_t invertedAlpha = 256 - input[3];
-	output[0] = (uint8_t)((alpha * input[0] + invertedAlpha * output[0]) >> 8);
-	output[1] = (uint8_t)((alpha * input[1] + invertedAlpha * output[1]) >> 8);
-	output[2] = (uint8_t)((alpha * input[2] + invertedAlpha * output[2]) >> 8);
+	output[0] = (uint8_t)((input[0] + invertedAlpha * output[0]) >> 8);
+	output[1] = (uint8_t)((input[1] + invertedAlpha * output[1]) >> 8);
+	output[2] = (uint8_t)((input[2] + invertedAlpha * output[2]) >> 8);
 	output[3] = 0xFF;
 }
 

--- a/Core/HdNesPack.cpp
+++ b/Core/HdNesPack.cpp
@@ -22,9 +22,9 @@ HdNesPack::~HdNesPack()
 void HdNesPack::BlendColors(uint8_t output[4], uint8_t input[4])
 {
 	uint8_t invertedAlpha = 256 - input[3];
-	output[0] = (uint8_t)((input[0] + invertedAlpha * output[0]) >> 8);
-	output[1] = (uint8_t)((input[1] + invertedAlpha * output[1]) >> 8);
-	output[2] = (uint8_t)((input[2] + invertedAlpha * output[2]) >> 8);
+	output[0] = input[0] + (uint8_t)((invertedAlpha * output[0]) >> 8);
+	output[1] = input[1] + (uint8_t)((invertedAlpha * output[1]) >> 8);
+	output[2] = input[2] + (uint8_t)((invertedAlpha * output[2]) >> 8);
 	output[3] = 0xFF;
 }
 
@@ -56,23 +56,25 @@ void HdNesPack::DrawCustomBackground(uint32_t *outputBuffer, uint32_t x, uint32_
 	uint32_t width = _hdData->Backgrounds[_backgroundIndex].Data->Width;
 	uint32_t *pngData = _hdData->Backgrounds[_backgroundIndex].data() + (y * _hdData->Scale * width) + (x * _hdData->Scale);
 
-	if(scale == 1) {
-		if(brightness == 255) {
+	if (scale == 1) {
+		if (brightness == 255) {
 			*outputBuffer = *pngData;
-		} else {
+		}
+		else {
 			*outputBuffer = AdjustBrightness((uint8_t*)pngData, brightness);
 		}
-	} else {
-		uint32_t *buffer = outputBuffer;
-		for(uint32_t i = 0; i < scale; i++) {
+	}
+	else {
+		uint32_t* buffer = outputBuffer;
+		for (uint32_t i = 0; i < scale; i++) {
 			memcpy(outputBuffer, pngData, sizeof(uint32_t) * scale);
 			outputBuffer += screenWidth;
 			pngData += width;
 		}
 
-		if(brightness < 255) {
-			for(uint32_t i = 0; i < scale; i++) {
-				for(uint32_t j = 0; j < scale; j++) {
+		if (brightness < 255) {
+			for (uint32_t i = 0; i < scale; i++) {
+				for (uint32_t j = 0; j < scale; j++) {
 					*buffer = AdjustBrightness((uint8_t*)buffer, brightness);
 					buffer++;
 				}

--- a/Core/HdNesPack.cpp
+++ b/Core/HdNesPack.cpp
@@ -55,32 +55,27 @@ void HdNesPack::DrawCustomBackground(uint32_t *outputBuffer, uint32_t x, uint32_
 	uint8_t brightness = _hdData->Backgrounds[_backgroundIndex].Brightness;
 	uint32_t width = _hdData->Backgrounds[_backgroundIndex].Data->Width;
 	uint32_t *pngData = _hdData->Backgrounds[_backgroundIndex].data() + (y * _hdData->Scale * width) + (x * _hdData->Scale);
+	uint32_t pixelColor;
 
-	if (scale == 1) {
-		if (brightness == 255) {
-			*outputBuffer = *pngData;
-		}
-		else {
-			*outputBuffer = AdjustBrightness((uint8_t*)pngData, brightness);
-		}
-	}
-	else {
-		uint32_t* buffer = outputBuffer;
-		for (uint32_t i = 0; i < scale; i++) {
-			memcpy(outputBuffer, pngData, sizeof(uint32_t) * scale);
-			outputBuffer += screenWidth;
-			pngData += width;
-		}
-
-		if (brightness < 255) {
-			for (uint32_t i = 0; i < scale; i++) {
-				for (uint32_t j = 0; j < scale; j++) {
-					*buffer = AdjustBrightness((uint8_t*)buffer, brightness);
-					buffer++;
-				}
-				buffer += screenWidth - scale;
+	for (uint32_t i = 0; i < scale; i++) {
+		for (uint32_t j = 0; j < scale; j++) {
+			if (brightness == 255) {
+				pixelColor = *pngData;
 			}
+			else {
+				pixelColor = AdjustBrightness((uint8_t*)pngData, brightness);
+			}
+			if (((uint8_t*)pngData)[3] == 0xff) {
+				*outputBuffer = pixelColor;
+			}
+			else if (((uint8_t*)pngData)[3]) {
+				BlendColors((uint8_t*)outputBuffer, (uint8_t*)(&pixelColor));
+			}
+			outputBuffer++;
+			pngData++;
 		}
+		outputBuffer += screenWidth - scale;
+		pngData += width - scale;
 	}
 }
 

--- a/Core/HdPackLoader.cpp
+++ b/Core/HdPackLoader.cpp
@@ -212,7 +212,17 @@ bool HdPackLoader::ProcessImgTag(string src)
 	if(PNGHelper::ReadPNG(fileData, pixelData, bitmapInfo.Width, bitmapInfo.Height)) {
 		bitmapInfo.PixelData.resize(pixelData.size() / 4);
 		memcpy(bitmapInfo.PixelData.data(), pixelData.data(), bitmapInfo.PixelData.size() * sizeof(bitmapInfo.PixelData[0]));
-
+		
+		//premultiply alpha
+		for (int i = 0; i < bitmapInfo.PixelData.size(); ++i) {
+			if (bitmapInfo.PixelData[i] < 0xFF000000) {
+				uint8_t output[4] = (uint8_t*)&(bitmapInfo.PixelData[i]);
+				uint8_t alpha = output[3] + 1;
+				output[0] = (uint8_t)((alpha * output[0]) >> 8);
+				output[1] = (uint8_t)((alpha * output[1]) >> 8);
+				output[2] = (uint8_t)((alpha * output[2]) >> 8);
+			}
+		}
 		_hdNesBitmaps.push_back(bitmapInfo);
 		return true;
 	} else {
@@ -541,6 +551,16 @@ void HdPackLoader::ProcessBackgroundTag(vector<string> &tokens, vector<HdPackCon
 				bgFileData = _data->BackgroundFileData.back().get();
 				bgFileData->PixelData.resize(pixelData.size() / 4);
 				memcpy(bgFileData->PixelData.data(), pixelData.data(), bgFileData->PixelData.size() * sizeof(bgFileData->PixelData[0]));
+				//premultiply alpha
+				for (int i = 0; i < bgFileData->PixelData.size(); ++i) {
+					if (bgFileData->PixelData[i] < 0xFF000000) {
+						uint8_t output[4] = (uint8_t*)&(bgFileData->PixelData[i]);
+						uint8_t alpha = output[3] + 1;
+						output[0] = (uint8_t)((alpha * output[0]) >> 8);
+						output[1] = (uint8_t)((alpha * output[1]) >> 8);
+						output[2] = (uint8_t)((alpha * output[2]) >> 8);
+					}
+				}
 				bgFileData->Width = width;
 				bgFileData->Height = height;
 				bgFileData->PngName = tokens[0];

--- a/Core/HdPackLoader.cpp
+++ b/Core/HdPackLoader.cpp
@@ -216,7 +216,7 @@ bool HdPackLoader::ProcessImgTag(string src)
 		//premultiply alpha
 		for (int i = 0; i < bitmapInfo.PixelData.size(); ++i) {
 			if (bitmapInfo.PixelData[i] < 0xFF000000) {
-				uint8_t output[4] = (uint8_t*)&(bitmapInfo.PixelData[i]);
+				uint8_t* output = (uint8_t*)(bitmapInfo.PixelData.data() + i);
 				uint8_t alpha = output[3] + 1;
 				output[0] = (uint8_t)((alpha * output[0]) >> 8);
 				output[1] = (uint8_t)((alpha * output[1]) >> 8);
@@ -554,7 +554,7 @@ void HdPackLoader::ProcessBackgroundTag(vector<string> &tokens, vector<HdPackCon
 				//premultiply alpha
 				for (int i = 0; i < bgFileData->PixelData.size(); ++i) {
 					if (bgFileData->PixelData[i] < 0xFF000000) {
-						uint8_t output[4] = (uint8_t*)&(bgFileData->PixelData[i]);
+						uint8_t* output = (uint8_t*)(bgFileData->PixelData.data() + i);
 						uint8_t alpha = output[3] + 1;
 						output[0] = (uint8_t)((alpha * output[0]) >> 8);
 						output[1] = (uint8_t)((alpha * output[1]) >> 8);


### PR DESCRIPTION
Add alpha blending when rendering custom backgound images so that behind backgound priority sprites and back color are not blocked by transparent pixels in the custom background images. Also use premultiply alpha to reduce the amount of calculation during rendering.