### PR TITLE
Libretro : Fix linux-arm7neonhf build

### DIFF
--- a/Libretro/Makefile
+++ b/Libretro/Makefile
@@ -64,7 +64,7 @@ ifeq ($(STATIC_LINKING), 1)
 EXT := a
 endif
 
-ifeq ($(platform), unix)
+ifneq (,$(findstring unix,$(platform)))
   EXT ?= so
    TARGET := $(TARGET_NAME)_libretro.$(EXT)
    fpic := -fPIC -pthread


### PR DESCRIPTION
- [Buildbot](http://paste.libretro.com/173353) is using `platform=unix-armv7-hardfloat-neon` for linux-arm7neonhf build

- So now it matches platform which contains `unix` not strictly `unix`
