### PR TITLE
Add libnx port

### DIFF
--- a/Core/DefaultVideoFilter.cpp
+++ b/Core/DefaultVideoFilter.cpp
@@ -1,16 +1,12 @@
 #include "stdafx.h"
 #include "DefaultVideoFilter.h"
 #include "EmulationSettings.h"
-#define _USE_MATH_DEFINES
-#include <math.h>
+#define M_PI  3.14159265358979323846264f
 #include <algorithm>
 #include "PPU.h"
 #include "DebugHud.h"
 #include "Console.h"
 
-#ifdef __HAVE_LIBNX__
-	#define M_PI  3.14159265358979323846264f
-	#endif
 
 DefaultVideoFilter::DefaultVideoFilter(shared_ptr<Console> console) : BaseVideoFilter(console)
 {

--- a/Core/DefaultVideoFilter.cpp
+++ b/Core/DefaultVideoFilter.cpp
@@ -2,6 +2,7 @@
 #include "DefaultVideoFilter.h"
 #include "EmulationSettings.h"
 #define _USE_MATH_DEFINES
+#define M_PI  3.14159265358979323846264f
 #include <math.h>
 #include <algorithm>
 #include "PPU.h"

--- a/Core/DefaultVideoFilter.cpp
+++ b/Core/DefaultVideoFilter.cpp
@@ -2,12 +2,15 @@
 #include "DefaultVideoFilter.h"
 #include "EmulationSettings.h"
 #define _USE_MATH_DEFINES
-#define M_PI  3.14159265358979323846264f
 #include <math.h>
 #include <algorithm>
 #include "PPU.h"
 #include "DebugHud.h"
 #include "Console.h"
+
+#ifdef __HAVE_LIBNX__
+	#define M_PI  3.14159265358979323846264f
+	#endif
 
 DefaultVideoFilter::DefaultVideoFilter(shared_ptr<Console> console) : BaseVideoFilter(console)
 {

--- a/Core/DefaultVideoFilter.cpp
+++ b/Core/DefaultVideoFilter.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "DefaultVideoFilter.h"
 #include "EmulationSettings.h"
+#include <math.h>
 #define M_PI  3.14159265358979323846264f
 #include <algorithm>
 #include "PPU.h"

--- a/Libretro/Makefile
+++ b/Libretro/Makefile
@@ -163,6 +163,15 @@ else ifeq ($(platform), vita)
    AR = arm-vita-eabi-ar
    CXXFLAGS += -Wl,-q -Wall -O3
   STATIC_LINKING = 1
+# Nintendo Switch (libnx)
+else ifeq ($(platform), libnx)
+   include $(DEVKITPRO)/libnx/switch_rules
+   TARGET := $(TARGET_NAME)_libretro_$(platform).a
+   DEFINES := -DSWITCH=1 -D__SWITCH__ -DARM -D_LARGEFILE_SOURCE
+   CFLAGS := $(DEFINES) -fPIE -I$(LIBNX)/include/ -ffunction-sections -fdata-sections -ftls-model=local-exec
+   CFLAGS += -march=armv8-a -mtune=cortex-a57 -mtp=soft -mcpu=cortex-a57+crc+fp+simd -ffast-math -D__BSD_VISIBLE=1 
+   CXXFLAGS := $(ASFLAGS) $(CFLAGS)
+   STATIC_LINKING = 1
 # Windows MSVC 2017 all architectures
 else ifneq (,$(findstring windows_msvc2017,$(platform)))
 

--- a/Libretro/Makefile
+++ b/Libretro/Makefile
@@ -167,7 +167,7 @@ else ifeq ($(platform), vita)
 else ifeq ($(platform), libnx)
    include $(DEVKITPRO)/libnx/switch_rules
    TARGET := $(TARGET_NAME)_libretro_$(platform).a
-   DEFINES := -DSWITCH=1 -D__SWITCH__ -DARM -D_LARGEFILE_SOURCE -D__HAVE_LIBNX__ -D__BYTE_ORDER=1234
+   DEFINES := -DSWITCH=1 -D__SWITCH__ -D_LARGEFILE_SOURCE -DHAVE_LIBNX -D__aarch64__
    CFLAGS := $(DEFINES) -fPIE -I$(LIBNX)/include/ -ffunction-sections -fdata-sections -ftls-model=local-exec 
    CFLAGS += -march=armv8-a -mtune=cortex-a57 -mtp=soft -mcpu=cortex-a57+crc+fp+simd -ffast-math
    CXXFLAGS := $(ASFLAGS) $(CFLAGS)

--- a/Libretro/Makefile
+++ b/Libretro/Makefile
@@ -167,8 +167,8 @@ else ifeq ($(platform), vita)
 else ifeq ($(platform), libnx)
    include $(DEVKITPRO)/libnx/switch_rules
    TARGET := $(TARGET_NAME)_libretro_$(platform).a
-   DEFINES := -DSWITCH=1 -D__SWITCH__ -DARM -D_LARGEFILE_SOURCE
-   CFLAGS := $(DEFINES) -fPIE -I$(LIBNX)/include/ -ffunction-sections -fdata-sections -ftls-model=local-exec
+   DEFINES := -DSWITCH=1 -D__SWITCH__ -DARM -D_LARGEFILE_SOURCE -D__APPLE__ -D__BYTE_ORDER=1234
+   CFLAGS := $(DEFINES) -fPIE -I$(LIBNX)/include/ -I$(PORTLIBS)/include/ -ffunction-sections -fdata-sections -ftls-model=local-exec
    CFLAGS += -march=armv8-a -mtune=cortex-a57 -mtp=soft -mcpu=cortex-a57+crc+fp+simd -ffast-math -D__BSD_VISIBLE=1 
    CXXFLAGS := $(ASFLAGS) $(CFLAGS)
    STATIC_LINKING = 1

--- a/Libretro/Makefile
+++ b/Libretro/Makefile
@@ -167,9 +167,9 @@ else ifeq ($(platform), vita)
 else ifeq ($(platform), libnx)
    include $(DEVKITPRO)/libnx/switch_rules
    TARGET := $(TARGET_NAME)_libretro_$(platform).a
-   DEFINES := -DSWITCH=1 -D__SWITCH__ -DARM -D_LARGEFILE_SOURCE -D__APPLE__ -D__BYTE_ORDER=1234
-   CFLAGS := $(DEFINES) -fPIE -I$(LIBNX)/include/ -I$(PORTLIBS)/include/ -ffunction-sections -fdata-sections -ftls-model=local-exec
-   CFLAGS += -march=armv8-a -mtune=cortex-a57 -mtp=soft -mcpu=cortex-a57+crc+fp+simd -ffast-math -D__BSD_VISIBLE=1 
+   DEFINES := -DSWITCH=1 -D__SWITCH__ -DARM -D_LARGEFILE_SOURCE -D__HAVE_LIBNX__ -D__BYTE_ORDER=1234
+   CFLAGS := $(DEFINES) -fPIE -I$(LIBNX)/include/ -ffunction-sections -fdata-sections -ftls-model=local-exec 
+   CFLAGS += -march=armv8-a -mtune=cortex-a57 -mtp=soft -mcpu=cortex-a57+crc+fp+simd -ffast-math
    CXXFLAGS := $(ASFLAGS) $(CFLAGS)
    STATIC_LINKING = 1
 # Windows MSVC 2017 all architectures

--- a/Utilities/CRC32.cpp
+++ b/Utilities/CRC32.cpp
@@ -16,12 +16,12 @@ extern const uint32_t Crc32Lookup[MaxSlice][256];
 #endif
 
 // define endianess and some integer data types
-#if defined(_MSC_VER) || defined(__MINGW32__)
+#if defined(_MSC_VER) || defined(__MINGW32__) || defined(__aarch64__)
 	// Windows always little endian
 	#define __BYTE_ORDER __LITTLE_ENDIAN
 #else
 	// defines __BYTE_ORDER as __LITTLE_ENDIAN or __BIG_ENDIAN
-#if defined(__APPLE__) || defined(__HAVE_LIBNX__)
+#if defined(__APPLE__) || defined(HAVE_LIBNX)
 		#include <machine/endian.h>
 	#else
 		#include <endian.h>

--- a/Utilities/CRC32.cpp
+++ b/Utilities/CRC32.cpp
@@ -21,7 +21,7 @@ extern const uint32_t Crc32Lookup[MaxSlice][256];
 	#define __BYTE_ORDER __LITTLE_ENDIAN
 #else
 	// defines __BYTE_ORDER as __LITTLE_ENDIAN or __BIG_ENDIAN
-	#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__HAVE_LIBNX__)
 		#include <machine/endian.h>
 	#else
 		#include <endian.h>

--- a/Utilities/stb_vorbis.cpp
+++ b/Utilities/stb_vorbis.cpp
@@ -224,7 +224,7 @@
    #if defined(_MSC_VER) || defined(__MINGW32__)
       #include <malloc.h>
    #endif
-   #if defined(__linux__) || defined(__linux) || defined(__EMSCRIPTEN__) || defined(__HAVE_LIBNX__)
+   #if defined(__linux__) || defined(__linux) || defined(__EMSCRIPTEN__) || defined(HAVE_LIBNX)
       #include <alloca.h>
    #endif
 #else // STB_VORBIS_NO_CRT

--- a/Utilities/stb_vorbis.cpp
+++ b/Utilities/stb_vorbis.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include "stb_vorbis.h"
+#include <alloca.h>
 // Ogg Vorbis audio decoder - v1.11 - public domain
 // http://nothings.org/stb_vorbis/
 //

--- a/Utilities/stb_vorbis.cpp
+++ b/Utilities/stb_vorbis.cpp
@@ -1,6 +1,5 @@
 #include "stdafx.h"
 #include "stb_vorbis.h"
-#include <alloca.h>
 // Ogg Vorbis audio decoder - v1.11 - public domain
 // http://nothings.org/stb_vorbis/
 //
@@ -225,7 +224,7 @@
    #if defined(_MSC_VER) || defined(__MINGW32__)
       #include <malloc.h>
    #endif
-   #if defined(__linux__) || defined(__linux) || defined(__EMSCRIPTEN__)
+   #if defined(__linux__) || defined(__linux) || defined(__EMSCRIPTEN__) || defined(__HAVE_LIBNX__)
       #include <alloca.h>
    #endif
 #else // STB_VORBIS_NO_CRT


### PR DESCRIPTION
This is a port of Mesen-libretro for Nintendo Switch. Performance is quite good if you overclock to 1700 Mhz, but with hdpacks performance isn't that great (50-45fps, dunno if something can be done on that reward). OGG support is broken for some reason (it crashes the emu by some recursive func) and I have some warnings when building stb_vorbis:
`../Utilities/stb_vorbis.cpp: In function 'int stb_vorbis_get_frame_short(stb_vorbis*, int, short int**, int)':
../Utilities/stb_vorbis.cpp:4798:28: warning: 'output' may be used uninitialized in this function [-Wmaybe-uninitialized]
 4798 |       convert_samples_short(num_c, buffer, 0, f->channels, output, 0, len);
      |       ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../Utilities/stb_vorbis.cpp: In function 'int stb_vorbis_get_frame_short_interleaved(stb_vorbis*, int, short int*, int)':
../Utilities/stb_vorbis.cpp:4724:35: warning: 'output' may be used uninitialized in this function [-Wmaybe-uninitialized]
 4724 |                buffer[i] += data[j][d_offset+o+i];
      |                             ~~~~~~^
../Utilities/stb_vorbis.cpp:4794:12: note: 'output' was declared here
 4794 |    float **output;
      |            ^~~~~~
../Utilities/stb_vorbis.cpp: In function 'int stb_vorbis_decode_filename(const char*, int*, int*, short int**)':
../Utilities/stb_vorbis.cpp:4786:49: warning: 'output' may be used uninitialized in this function [-Wmaybe-uninitialized]
 4786 |          copy_samples(buffer[i]+b_offset, data[i]+d_offset, samples);
      |                                           ~~~~~~^
../Utilities/stb_vorbis.cpp:4794:12: note: 'output' was declared here
 4794 |    float **output;
      |            ^~~~~~
../Utilities/stb_vorbis.cpp: In function 'int stb_vorbis_decode_memory(const uint8*, int, int*, int*, short int**)':
../Utilities/stb_vorbis.cpp:4786:49: warning: 'output' may be used uninitialized in this function [-Wmaybe-uninitialized]
 4786 |          copy_samples(buffer[i]+b_offset, data[i]+d_offset, samples);
      |                                           ~~~~~~^
../Utilities/stb_vorbis.cpp:4794:12: note: 'output' was declared here
 4794 |    float **output;
      |            ^~~~~~`

I'm open for suggestions.

`