### PR TITLE
Libretro: Fixes ogg crashes on static platforms

### DIFF
--- a/Libretro/Makefile
+++ b/Libretro/Makefile
@@ -306,6 +306,15 @@ else
   LD = $(CXX)
 endif
 
+CONFLICTING_NAMES=std_vorbis std_vorbis_close stb_vorbis_open_memory stb_vorbis_get_info \
+  stb_vorbis_seek stb_vorbis_get_samples_short_interleaved stb_vorbis_seek_start \
+  stb_vorbis_get_file_offset
+ifeq ($(STATIC_LINKING),1)
+  PREFIX_DEFINES := $(foreach name,$(CONFLICTING_NAMES),-D$(name)=core_$(name))
+  CFLAGS   += $(PREFIX_DEFINES)
+  CXXFLAGS += $(PREFIX_DEFINES)
+endif
+
 include Makefile.common
 
 OBJECTS := $(SOURCES_C:.c=.o) $(SOURCES_CXX:.cpp=.o)


### PR DESCRIPTION
This PR fixes crashes when using HD packs that contains at least one ogg music, the crash seemed to happen during playing on static platforms. The cause was that the frontend also uses stb_vorbis, but has a few unused functions stripped, this made the core use `stb_vorbis_get_samples_short_interleaved` from Mesen, and everything else from RA. 
So for static platforms, we prefix used stb_vorbis functions so that we get no duplicate symbols, and doesn't impact other platforms or standalone Mesen

(cc @slash0042)