### PR TITLE
Fix a bug where Language detection could fail to happen

### DIFF
--- a/GUI.NET/Forms/ResourceHelper.cs
+++ b/GUI.NET/Forms/ResourceHelper.cs
@@ -37,6 +37,10 @@ namespace Mesen.GUI.Forms
 
 		public static Language GetCurrentLanguage()
 		{
+			if (_language == Language.SystemDefault)
+			{
+				_language = DetectLanguage();
+			}
 			return _language;
 		}
 
@@ -66,18 +70,7 @@ namespace Mesen.GUI.Forms
 		public static void LoadResources(Language language)
 		{
 			if(language == Language.SystemDefault) {
-				switch(System.Globalization.CultureInfo.CurrentUICulture.TwoLetterISOLanguageName) {
-					default:
-					case "en": language = Language.English; break;
-					case "fr": language = Language.French; break;
-					case "ja": language = Language.Japanese; break;
-					case "ru": language = Language.Russian; break;
-					case "es": language = Language.Spanish; break;
-					case "uk": language = Language.Ukrainian; break;
-					case "pt": language = Language.Portuguese; break;
-					case "zh": language = Language.Chinese; break;
-					case "it": language = Language.Italian; break;
-				}
+				language = DetectLanguage();
 			}
 
 			string filename;
@@ -105,6 +98,25 @@ namespace Mesen.GUI.Forms
 			using(Stream stream = ResourceManager.GetZippedResource(enFilename)) {
 				_enResources.Load(stream);
 			}
+		}
+
+		private static Language DetectLanguage()
+		{
+			Language language = Language.SystemDefault;
+			switch (System.Globalization.CultureInfo.CurrentUICulture.TwoLetterISOLanguageName)
+			{
+				default:
+				case "en": language = Language.English; break;
+				case "fr": language = Language.French; break;
+				case "ja": language = Language.Japanese; break;
+				case "ru": language = Language.Russian; break;
+				case "es": language = Language.Spanish; break;
+				case "uk": language = Language.Ukrainian; break;
+				case "pt": language = Language.Portuguese; break;
+				case "zh": language = Language.Chinese; break;
+				case "it": language = Language.Italian; break;
+			}
+			return language;
 		}
 
 		public static string GetMessage(string id, params object[] args)


### PR DESCRIPTION
While checking the startup code in Program.cs, I noticed that there were a series of localized error messages, but then I checked how Language Detection worked, and saw that _language was never initialized at that point in the program, so it would always display in English no matter what.